### PR TITLE
mypy: Remove follow-imports option from invocation

### DIFF
--- a/pylama/lint/pylama_mypy.py
+++ b/pylama/lint/pylama_mypy.py
@@ -18,7 +18,7 @@ class Linter(Abstract):
     def run_check(self, ctx: RunContext):
         """Check code with mypy."""
         # Support stdin
-        args = [ctx.temp_filename, "--follow-imports=skip", "--show-column-numbers"]
+        args = [ctx.temp_filename, "--show-column-numbers"]
         stdout, _, _ = api.run(args)  # noqa
 
         for line in stdout.splitlines():


### PR DESCRIPTION
Follow imports is not recommended by the Mypy authors if it can be avoided[1], but adding it to the invocation forces users down that path. This can lead to unexpected errors trying to use `mypy` within pylama.

This commit removes the forced option to skip following imports. Users will see the `mypy` linter take longer to run in most casees. If that is a problem, they can still configure it not to follow imports in any of the ways the tool supports.

[1] - https://mypy.readthedocs.io/en/stable/running_mypy.html#follow-imports