### PR TITLE
Fix requirements handling in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ tests=[
             'types-toml'
         ],
         all=OPTIONAL_LINTERS, **{linter: [linter] for linter in OPTIONAL_LINTERS},
-        toml='toml>=2.0.1',
+        toml='tomli>=1.2.3; python_version < "3.11"',
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -4,32 +4,22 @@
 
 import pathlib
 
+import pkg_resources
 from setuptools import setup
+
+
+def parse_requirements(path: str) -> 'list[str]':
+    with pathlib.Path(path).open(encoding='utf-8') as requirements:
+        return [str(req) for req in pkg_resources.parse_requirements(requirements)]
+
 
 OPTIONAL_LINTERS = ['pylint', 'eradicate', 'radon', 'mypy', 'vulture']
 
 
 setup(
-    install_requires=[
-        'mccabe>=0.7.0',
-        'pycodestyle>=2.9.1',
-        'pydocstyle>=6.1.1',
-        'pyflakes>=2.5.0'
-    ],
+    install_requires=parse_requirements('requirements/requirements.txt'),
     extras_require=dict(
-tests=[
-            'pytest>=7.1.2',
-            'pytest-mypy',
-            'eradicate>=2.0.0',
-            'radon>=5.1.0',
-            'mypy',
-            'pylint>=2.11.1',
-            'pylama-quotes',
-            'toml',
-            'vulture',
-            'types-setuptools',
-            'types-toml'
-        ],
+        tests=parse_requirements('requirements/requirements-tests.txt'),
         all=OPTIONAL_LINTERS, **{linter: [linter] for linter in OPTIONAL_LINTERS},
         toml='tomli>=1.2.3; python_version < "3.11"',
     ),

--- a/setup.py
+++ b/setup.py
@@ -4,22 +4,52 @@
 
 import pathlib
 
-import pkg_resources
 from setuptools import setup
 
 
-def parse_requirements(path: str) -> 'list[str]':
-    with pathlib.Path(path).open(encoding='utf-8') as requirements:
-        return [str(req) for req in pkg_resources.parse_requirements(requirements)]
+# tokenize requirements file
+# Note: according to the specification
+# at https://pip.pypa.io/en/stable/reference/requirements-file-format/
+# line continuations are processed before comments, however pkg_resources source code
+# says otherwise:
+# def parse_requirements(strs: _NestedStr) -> map[Requirement]:
+#     return map(Requirement, join_continuation(map(drop_comment, yield_lines(strs))))
+# Here we follow the actual implementation.
+def join_continuation(lines):
+    lines = iter(lines)
+    for item in lines:
+        while item.endswith('\\'):
+            try:
+                item = item[:-2].strip() + next(lines)
+            except StopIteration:
+                return
+        yield item
+
+
+def drop_comments(lines):
+    for item in lines:
+        yield item.partition(' #')[0]
+
+
+def drop_whites(lines):
+    for item in lines:
+        stripped = item.strip()
+        if stripped:
+            yield stripped
+
+
+def requirements_from_file(path: str) -> 'list[str]':
+    with pathlib.Path(path).open(encoding='utf-8') as f:
+        return list(drop_whites(join_continuation(drop_comments(f))))
 
 
 OPTIONAL_LINTERS = ['pylint', 'eradicate', 'radon', 'mypy', 'vulture']
 
 
 setup(
-    install_requires=parse_requirements('requirements/requirements.txt'),
+    install_requires=requirements_from_file('requirements/requirements.txt'),
     extras_require=dict(
-        tests=parse_requirements('requirements/requirements-tests.txt'),
+        tests=requirements_from_file('requirements/requirements-tests.txt'),
         all=OPTIONAL_LINTERS, **{linter: [linter] for linter in OPTIONAL_LINTERS},
         toml='tomli>=1.2.3; python_version < "3.11"',
     ),


### PR DESCRIPTION
Makes `setup.py` use requirements files again instead of out of date manual list.
`pkg_resources` dependency is replaced by simple extraction of non-comment fields.
`toml` package dependency is also fixed.